### PR TITLE
fix: linkear etiquetas a un perfil

### DIFF
--- a/src/server/routers/modelosRouter.ts
+++ b/src/server/routers/modelosRouter.ts
@@ -91,7 +91,7 @@ export const modeloRouter = router({
                 genero: input.genero,
                 edad: input.edad,
                 etiquetas: {
-                    connect: (input.etiquetas ?? []).map((etiqueta) => {
+                    set: (input.etiquetas ?? []).map((etiqueta) => {
                         return {
                             id: etiqueta.id,
                         }


### PR DESCRIPTION
Aquí completamos con lo que sería asociar las etiquetas con perfiles. Para esto, se realiza lo siguiente: Al envíar esos datos a modificar en el back (por ejemplo: aprentando un botón `Guardar`), se van a enviar las etiquetas que quedarían asignadas a tal perfil. En el back lo que se realiza en simples palabras, reemplaza la lista (array) de etiquetas anteriores por la nueva que se envió a la función que se está ejecutando, editando el perfil.