### PR TITLE
add: Estilado responsive de la paginación para mobile

### DIFF
--- a/src/components/modelos/table/Pagination.tsx
+++ b/src/components/modelos/table/Pagination.tsx
@@ -35,7 +35,7 @@ const PaginationComp = <TData,>({ table }: PaginationProps<TData>) => {
             </Button>
             <span className='flex items-center gap-1'>
               <div className='hidden sm:block'>Página</div>
-              <strong>
+              <strong className='text-sm sm:text-base'>
                 {table.getState().pagination.pageIndex + 1} de{' '}
                 {table.getPageCount().toLocaleString()}
               </strong>
@@ -74,10 +74,14 @@ const PaginationComp = <TData,>({ table }: PaginationProps<TData>) => {
             onChange={(e) => {
               table.setPageSize(Number(e.target.value));
             }}
-            className='rounded border bg-white/90 p-1'
+            className='rounded border bg-white/90 p-1 text-sm sm:text-base'
           >
             {[2, 5, 10, 15, 20].map((pageSize) => (
-              <option key={pageSize} value={pageSize}>
+              <option
+                className='text-sm sm:text-base'
+                key={pageSize}
+                value={pageSize}
+              >
                 Mostrar {pageSize}
               </option>
             ))}


### PR DESCRIPTION
En este PR se modificó el estilado de paginación adaptandolo a diferentes tamaños de pantalla. Dejo insertado diferentes tipos de paginación dependiendo la pantalla:

**- Mobile:** 
<img width="286" alt="image" src="https://github.com/expomanager/expo-manager/assets/101568983/9b4e891f-4baf-437a-8f8b-3f134f299142">

**- 650px:**
<img width="479" alt="image" src="https://github.com/expomanager/expo-manager/assets/101568983/28dc2b40-415c-4f87-9c85-b7a7a81bcac5">

**- 1024px hacia arriba: (Notebook o computadora)**
<img width="770" alt="image" src="https://github.com/expomanager/expo-manager/assets/101568983/a8c2e874-517b-4996-bbaf-e6cabf870a74">
