### PR TITLE
add: backend para expo-formulario

### DIFF
--- a/src/app/api/formulario/route.ts
+++ b/src/app/api/formulario/route.ts
@@ -20,6 +20,9 @@ export async function POST(req: NextRequest, res: NextResponse) {
                 nombreCompleto: data.nombreCompleto,
                 nombrePila: nombrePila,
                 telefono: telefonoSinSeparaciones,
+                etiquetas: {
+                    connect: {id: process.env.MODELO_ETIQUETA_ID}
+                }
             }
         });
         return NextResponse.json(response, {status: 201});


### PR DESCRIPTION
En este PR se integra el backend que se utilizaba en expo-formulario para utilizarlo acá. De esta forma, desde expo-formulario se hará la petición a `expo-manager.vercel.app/api/formulario` con método POST. Desde expo-formulario se hará la petición a esta ruta pasando como data el nombre completo y teléfono obtenidos del formulario.