### PR TITLE
feat: Backend para set masivo de etiquetas

### DIFF
--- a/src/server/routers/etiquetaRouter.ts
+++ b/src/server/routers/etiquetaRouter.ts
@@ -204,4 +204,29 @@ export const etiquetaRouter = router({
         });
       }
     }),
+  setMasivo: protectedProcedure
+    .input(
+      z.object({
+        etiquetaIds: z.array(z.string().uuid()),
+        modeloIds: z.array(z.string().uuid()),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      return await Promise.all(
+        input.modeloIds.map(async (modeloId) => {
+          await ctx.prisma.perfil.update({
+            where: {
+              id: modeloId,
+            },
+            data: {
+              etiquetas: {
+                connect: input.etiquetaIds.map((etiquetaId) => ({
+                  id: etiquetaId,
+                })),
+              },
+            },
+          });
+        })
+      );
+    }),
 });


### PR DESCRIPTION
Se agregó la funcion `setMasivo` en el `etiquetaRouter` que recibe un array de ids etiqueta y un array de ids de modelo y se le agregan esas etiquetas a las modelos 