### PR TITLE
Expo 130 fix finales de eventos

### DIFF
--- a/src/app/(dashboard)/eventos/page.tsx
+++ b/src/app/(dashboard)/eventos/page.tsx
@@ -62,7 +62,7 @@ const EventosPage = () => {
                 setNone();
               }
             }}
-            placeholder='Buscar evento o subevento' style={{ paddingRight: '20px' }}
+            placeholder='Buscar evento o subevento' className="pr-5"
            />
         </div>
       </div>

--- a/src/components/eventos/eventomodal.tsx
+++ b/src/components/eventos/eventomodal.tsx
@@ -318,7 +318,7 @@ const EventoModal = ({ action, evento }: EventoModalProps) => {
                       }}
                       required 
                     />
-                    <Button
+                    <Button variant='destructive'
                     onClick={() => {
                     const updatedSubeventos = [...modalData.subeventos];
                     updatedSubeventos.splice(index, 1); 
@@ -326,7 +326,7 @@ const EventoModal = ({ action, evento }: EventoModalProps) => {
                   subeventos: updatedSubeventos,
     });
   }}
-  style={{ backgroundColor: 'red', color: 'white' }}
+  
 >
   Eliminar subevento
 </Button>


### PR DESCRIPTION
Hola buen día, en este PR se realizaron las siguientes cosas para mejorar la sección de Eventos.

-  se modifico el background/relleno del botón de "eliminar subevento" para el color rojo, referenciando la eliminación del mismo.
- se modifico el "editar" por el "confirmar edición" para que se entienda un poco mas la utilización del botón(si ya realizaste tu edición de evento/subevento, puedas confirmar clickeando ahí)
- había muy poca separación y estaban muy pegados el placeholder con la lupa del SearchInput, asi que se los separo un poco para que se entienda mejor el placeholder.
- se modifico el texto de "eliminar" en la edición de evento, para que se explique y se tenga una referencia que si el evento tiene subevento, primero deberá eliminar el/los mismos.


Cualquier cosa, duda o problema me avisan. Gracias!