### PR TITLE
feat: Redirección a envío de mail mediante botón

### DIFF
--- a/src/components/modelo/ModeloPageContent.tsx
+++ b/src/components/modelo/ModeloPageContent.tsx
@@ -228,18 +228,23 @@ const ModeloPageContent = ({ modelo }: ModeloPageContentProps) => {
                 </a>
               )}
               {modelo.mail && (
-                <p className='w-full whitespace-nowrap'>
-                  <MailIcon className='mr-2 inline-block h-5 w-5 fill-black' />
-                  <span>{modelo.mail}</span>
-                </p>
-              )}
-              {modelo.dni && (
-                <p>
-                  <DNIIcon className='mr-2 inline-block h-5 w-5 fill-black' />
-                  <span>{modelo.dni}</span>
-                </p>
+                <a
+                  className='cursor-pointer rounded-md bg-[#ea1c1c] p-2'
+                  title={`Mail de ${modelo.nombreCompleto}`}
+                  href={`mailto:${modelo.mail}`}
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  <MailIcon className='h-4 w-4 fill-white' />
+                </a>
               )}
             </div>
+            {modelo.dni && (
+              <p>
+                <DNIIcon className='mr-2 inline-block h-5 w-5 fill-black' />
+                <span>{modelo.dni}</span>
+              </p>
+            )}
             {modelo.nombresAlternativos.length > 0 && (
               <p className='text-sm text-black/80'>
                 Nombres alternativos: {modelo.nombresAlternativos.join(', ')}


### PR DESCRIPTION
En este PR se crea un botón con la forma de correo para poder redireccionar al usuario a envíar un mail a tal modelo mediante el apretar tal botón. Además se ubicó este botón en la misma fila que los otros iconos como WhatsApp, Instagram etc. De esta manera, queda el DNI abajo de toda esta fila de iconos.

<img width="818" alt="image" src="https://github.com/expomanager/expo-manager/assets/101568983/492c5620-56f4-4ffa-9d9a-2a49561fa06b">
