### PR TITLE
feat: Cambio de color de fondo en layout con variable de entorno

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "react": "^18",
         "react-day-picker": "^8.10.0",
         "react-dom": "^18",
-        "recharts": "^2.12.4",
+        "recharts": "^2.12.7",
         "sonner": "^1.4.3",
         "string-comparison": "^1.3.0",
         "tailwind-merge": "^2.2.1",
@@ -6743,9 +6743,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.4.tgz",
-      "integrity": "sha512-dM4skmk4fDKEDjL9MNunxv6zcTxePGVEzRnLDXALRpfJ85JoQ0P0APJ/CoJlmnQI0gPjBlOkjzrwrfQrRST3KA==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "^18",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18",
-    "recharts": "^2.12.4",
+    "recharts": "^2.12.7",
     "sonner": "^1.4.3",
     "string-comparison": "^1.3.0",
     "tailwind-merge": "^2.2.1",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import Sidebar from '@/components/layout/Sidebar';
 import Topbar from '@/components/layout/Topbar';
 import VerificarAuth from '@/components/auth/VerificarAuth';
 import { Toaster } from '@/components/ui/sonner';
+import { cn } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: 'Expo Manager',
@@ -14,6 +15,8 @@ const RootLayout = ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
+  const esDemo = process.env.NEXT_PUBLIC_ES_DEMO === 'true';
+
   return (
     <div className='grid grid-cols-1 md:grid-cols-[auto,1fr]'>
       <div className='hidden md:block'>
@@ -21,7 +24,12 @@ const RootLayout = ({
       </div>
       <div className='grid grid-rows-[auto,1fr]'>
         <Topbar />
-        <main className='h-[calc(100vh-4rem)] flex-1 overflow-y-auto bg-background'>
+        <main
+          className={cn(
+            'h-[calc(100vh-4rem)] flex-1 overflow-y-auto',
+            esDemo ? 'bg-[#fff5ef]' : ' bg-background'
+          )}
+        >
           <VerificarAuth />
           {children}
         </main>

--- a/src/components/dashboard/ModelosChart.tsx
+++ b/src/components/dashboard/ModelosChart.tsx
@@ -42,6 +42,12 @@ const ModelosChart = ({ data, className }: BarChartProps) => {
     });
   }, [data]);
 
+  const error = console.error;
+  console.error = (...args: any) => {
+    if (/defaultProps/.test(args[0])) return;
+    error(...args);
+  };
+
   return (
     <ResponsiveContainer
       height={'100%'}
@@ -49,7 +55,7 @@ const ModelosChart = ({ data, className }: BarChartProps) => {
       className={cn(className)}
     >
       <RechartChart id='modelosChart' data={dataMostrar} className='h-full'>
-        <XAxis dataKey='fecha' />
+        <XAxis dataKey={'fecha'} />
         <YAxis />
         <Tooltip
           content={({ active, payload, label }) => (
@@ -62,7 +68,7 @@ const ModelosChart = ({ data, className }: BarChartProps) => {
           )}
         />
         <Bar
-          dataKey='participantes'
+          dataKey='modelos'
           className='fill-slate-700'
           activeBar={<Rectangle stroke='black' />}
         />


### PR DESCRIPTION
En este PR se aborda la problemática de poder diferenciar ExpoManager Demo de su versión de producción con solo mirar la pantalla. La solución elegida fue un leve cambio en el color de fondo.
DEMO:
![image](https://github.com/expomanager/expo-manager/assets/74215078/4fd75edf-91eb-4487-bed8-a375c00d51f5)
PROD:
![image](https://github.com/expomanager/expo-manager/assets/74215078/d54dc005-48cd-40f5-9c6e-468f1880a5e5)
La solución implica una nueva variable de entorno `NEXT_PUBLIC_ES_DEMO` que debe ser setteada a `"true"` para que se aplique el cambio de fondo

*También se arregla un leve problemita que se generó cuando se hizo [este PR](https://github.com/expomanager/expo-manager/pull/91)
