### PR TITLE
Arreglo de los ID legibles

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model Cuenta {
 
 model Perfil {
   id        String @id @default(uuid())
-  idLegible Int?   @default(autoincrement()) @map("id_legible")
+  idLegible Int    @map("id_legible")
 
   telefono            String    @unique
   nombreCompleto      String    @map("nombre_completo")

--- a/src/app/api/formulario/route.ts
+++ b/src/app/api/formulario/route.ts
@@ -1,3 +1,4 @@
+import { getHighestIdLegible } from '@/lib/server';
 import { prisma } from '@/server/db';
 import { TipoEtiqueta } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
@@ -58,6 +59,8 @@ export async function POST(req: NextRequest, res: NextResponse) {
       );
     }
 
+    const idLegibleMasAlto = await getHighestIdLegible(prisma);
+
     const response = await prisma?.perfil.upsert({
       where: {
         telefono: telefonoSinSeparaciones,
@@ -75,6 +78,7 @@ export async function POST(req: NextRequest, res: NextResponse) {
         },
       },
       create: {
+        idLegible: idLegibleMasAlto + 1,
         nombreCompleto: data.nombreCompleto,
         nombrePila: nombrePila,
         telefono: telefonoSinSeparaciones,

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { MensajeStatus } from '@prisma/client';
 import { join as pathJoin } from 'path';
 import { enviarMensajeUnaSolaVez } from '@/server/routers/whatsappRouter';
+import { getHighestIdLegible } from '@/lib/server';
 
 export const revalidate = 0;
 const FECHA_LIMITE_MENSAJE_AUTOMATICO = new Date(2024, 4, 10);
@@ -123,6 +124,8 @@ async function crearMensaje(value: ReceivedMessage) {
     };
   }
 
+  const idLegibleMasAlto = await getHighestIdLegible(prisma);
+
   const mensajeCreado = await prisma.mensaje.create({
     data: {
       wamId: message.id,
@@ -134,6 +137,7 @@ async function crearMensaje(value: ReceivedMessage) {
             telefono: message.from,
           },
           create: {
+            idLegible: idLegibleMasAlto + 1,
             nombreCompleto: contact.profile.name,
             nombrePila: contact.profile.name.split(' ')[0],
             telefono: contact.wa_id,

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+export async function getHighestIdLegible(prisma: PrismaClient) {
+  const perfilMayorIdLegible = await prisma.perfil.findFirst({
+    orderBy: {
+      idLegible: 'desc',
+    },
+  });
+  const idLegible = perfilMayorIdLegible?.idLegible ?? 0;
+  return idLegible;
+}

--- a/src/server/routers/modelosRouter.ts
+++ b/src/server/routers/modelosRouter.ts
@@ -1,13 +1,14 @@
+import { getHighestIdLegible } from '@/lib/server';
+import { normalize } from '@/lib/utils';
+import { modeloSchemaCrearOEditar } from '@/server/schemas/modelo';
 import { protectedProcedure, publicProcedure, router } from '@/server/trpc';
 import { MessageJson } from '@/server/types/whatsapp';
 import { Mensaje, Perfil, Prisma, TipoEtiqueta } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { subDays } from 'date-fns';
-import { z } from 'zod';
 import levenshtein from 'string-comparison';
+import { z } from 'zod';
 import { ModelosSimilarity } from '../types/modelos';
-import { normalize } from '@/lib/utils';
-import { modeloSchemaCrearOEditar } from '@/server/schemas/modelo';
 
 export const modeloRouter = router({
   getAll: protectedProcedure.query(async ({ ctx }) => {
@@ -160,8 +161,12 @@ export const modeloRouter = router({
       })
     )
     .mutation(async ({ input, ctx }) => {
+      const idLegibleMasAlto = await getHighestIdLegible(ctx.prisma);
       return await ctx.prisma.perfil.create({
-        data: input,
+        data: {
+          ...input,
+          idLegible: idLegibleMasAlto + 1,
+        },
       });
     }),
   createManual: publicProcedure
@@ -246,8 +251,11 @@ export const modeloRouter = router({
         }
       }
 
+      const idLegibleMasAlto = await getHighestIdLegible(ctx.prisma);
+
       return await ctx.prisma.perfil.create({
         data: {
+          idLegible: idLegibleMasAlto + 1,
           nombreCompleto: input.modelo.nombreCompleto,
           nombrePila: input.modelo.nombreCompleto.split(' ')[0],
           telefono: telefono,


### PR DESCRIPTION
En este PR se arregla el problema con los ID legibles, ahora se tiene en cuenta el más grande (que coincide con el más reciente) para generar el que se está creando.
Se cambió tanto en el schema de prisma para que no sea más autoincremental y en todos los lugares donde fue necesario