### PR TITLE
feat: Etiqueta agregada automáticamente al seleccionarla

### DIFF
--- a/src/components/modelos/FormCrearModelo.tsx
+++ b/src/components/modelos/FormCrearModelo.tsx
@@ -160,7 +160,13 @@ const FormCrearModelo = ({
         type='date'
         placeholder='Fecha de nacimiento'
         className='py-4'
-        value={modalModelo.modelo.fechaNacimiento?.toISOString().split('T')[0]}
+        value={
+          modalModelo.modelo.fechaNacimiento
+            ? isNaN(modalModelo.modelo.fechaNacimiento?.getTime())
+              ? ''
+              : modalModelo.modelo.fechaNacimiento.toISOString().split('T')[0]
+            : ''
+        }
         onChange={(e) =>
           useCrearModeloModal.setState({
             modelo: {


### PR DESCRIPTION
En este PR se realiza la siguiente modificación:

- Se elimina en la sección de etiquetas en la creación manual de un participante, el botón para agregarle la etiqueta seleccionada al participante. De esta forma, con solo seleccionar la etiqueta en el ComboBox, esta se agrega automáticamente ahorrando al usuario un click.