### PR TITLE
Expo 227 base de datos persistir estado en back

### DIFF
--- a/src/app/(dashboard)/modelo/[modeloId]/page.tsx
+++ b/src/app/(dashboard)/modelo/[modeloId]/page.tsx
@@ -47,7 +47,12 @@ const ModeloPage = ({ params }: ModeloPageProps) => {
   return (
     <div className='h-full px-4 pt-4'>
       <div className='flex items-center gap-x-4'>
-        <ArrowLeft className='cursor-pointer' onClick={() => router.back()} />
+        <ArrowLeft
+          className='cursor-pointer'
+          onClick={() => {
+            router.back();
+          }}
+        />
       </div>
       {isLoadingModelo || isLoadingComentarios || !modelo || !comentarios ? (
         <div className='flex h-full w-full items-center justify-center'>

--- a/src/components/modelos/table/Pagination.tsx
+++ b/src/components/modelos/table/Pagination.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import { type Table } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import {
@@ -7,21 +6,40 @@ import {
   ChevronsLeft,
   ChevronsRight,
 } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface PaginationProps<TData> {
   table: Table<TData>;
 }
 
 const PaginationComp = <TData,>({ table }: PaginationProps<TData>) => {
-  const router = useRouter();
+  const [firstRender, setFirstRender] = useState(true);
 
   useEffect(() => {
     const pageIndex = table.getState().pagination.pageIndex + 1;
     const params = new URLSearchParams(window.location.search);
+    if (firstRender) {
+      setFirstRender(false);
+
+      if (params.has('page')) {
+        const page = Number(params.get('page'));
+        if (page !== pageIndex) {
+          table.setPageIndex(page - 1);
+        }
+      }
+      return;
+    }
+
     params.set('page', pageIndex.toString());
 
-    router.push(`?${params.toString()}`);
+    window.history.pushState(
+      {
+        page: pageIndex,
+      },
+      '',
+      `?${params.toString()}`
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table.getState().pagination.pageIndex]);
 
   return (


### PR DESCRIPTION
Hola, en este PR se cumplio el objetivo de persistir el estado en back, para que no solo aparezca el numero de tabla de modelo en la URL, sino que tambien para que al apretar una modelo y obtener su vista particular, cuando volvemos atras, que no vuelva al principio de la lista sino que se mantenga en la del numero que apretamos la modelo. Gracias.