### PR TITLE
Expo 227 base de datos persistir estado en back

### DIFF
--- a/src/components/modelos/table/Pagination.tsx
+++ b/src/components/modelos/table/Pagination.tsx
@@ -23,7 +23,6 @@ const PaginationComp = <TData,>({ table }: PaginationProps<TData>) => {
     if (firstRender) {
       setFirstRender(false);
 
-      // Cargar valores de 'page' y 'pageSize' de los parámetros de la URL
       if (params.has('page')) {
         const page = Number(params.get('page'));
         if (page !== pageIndex) {
@@ -57,7 +56,7 @@ const PaginationComp = <TData,>({ table }: PaginationProps<TData>) => {
     table.getState().pagination.pageSize,
   ]);
 
-  const noData = table.getRowModel().rows.length === 0;
+  const noData = table.getPageCount() === 0;
 
   return (
     <>


### PR DESCRIPTION
En este nuevo PR de la task se ha solucionado distintos bugs que habian a al hora de la  primera muestra del mismo. Aca hay algunos ejemplos.

- Guardado de estado en back a la hora de filtrado por etiqueta y/o por nombre.
- Guardado del estado de "Mostrar N" tanto en el back como en la URL
- fixeado que cuando no hay data en la tabla no te aparezca "1 de 0" sino "0 de 0"  (Mismo caso solucionado cuando aparecía "3 de 1") 