### PR TITLE
fix: Nacionalidad y residencia al entrar desde formulario

### DIFF
--- a/src/app/api/formulario/route.ts
+++ b/src/app/api/formulario/route.ts
@@ -156,6 +156,24 @@ export async function POST(req: NextRequest, res: NextResponse) {
       ...(telefonoSecundarioSinSeparaciones && {
         telefonoSecundario: telefonoSecundarioSinSeparaciones,
       }),
+      paisNacimiento: pais,
+      provinciaNacimiento: provincia,
+      residencia: {
+        connectOrCreate: {
+          where: {
+            latitud_longitud: {
+              latitud: localidad.latitud,
+              longitud: localidad.longitud,
+            },
+          },
+          create: {
+            latitud: localidad.latitud,
+            longitud: localidad.longitud,
+            localidad: localidad.nombre,
+            provincia: provinciaArgentina,
+          },
+        },
+      },
     };
 
     const response = await prisma.perfil.upsert({


### PR DESCRIPTION
En este PR se soluciona el problema de que no se agregue la data de nacionalidad y residencia de un participante al anotarse desde el formulario